### PR TITLE
[#184292040] Refactoring der Docker Rolle

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,11 @@
+---
+warn_list:
+  - name[template]
+  - role-name
+  - yaml[truthy]
+
+# Ansible > 2.10
+skip_list:
+  - fqcn[action-core]
+  - fqcn[action]
+  - fqcn[canonical]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,90 @@
 ---
-
-name: "CI"
-
+name: CI
 on:
+  workflow_dispatch:
   pull_request:
-    branches:
-      - "*"
   push:
-    branches:
-      - "main"
-      - "master"
+  schedule:
+    - cron: '30 1 * * 3'
 
 jobs:
-  test:
-    runs-on: "ubuntu-20.04"
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    outputs:
+      container_supported: ${{ steps.get_min_ansible_container_version.outputs.result }}
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v3
+
+      - name: Pull Lint image
+        run: docker pull -q ghcr.io/rheinwerk/molecule:lint
+
+      - name: Ansible Linting
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/git -w /git ghcr.io/rheinwerk/molecule:lint ansible-lint --force-color -p --offline /git
+
+      - name: Yaml Linting
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/git -w /git ghcr.io/rheinwerk/molecule:lint yamllint -f colored /git
+
+      - name: Get min_ansible_container_version from meta/main.yml
+        id: get_min_ansible_container_version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq ".galaxy_info.min_ansible_container_version" ${GITHUB_WORKSPACE}/meta/main.yml
+
+  molecule:
+    name: Molecule for Ansible ${{ matrix.ansible_version }} / ${{ matrix.distro }} / Python ${{ matrix.python_version }}
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
+    needs: lint
+    if: needs.lint.outputs.container_supported != 'X'
     strategy:
+      fail-fast: false
       matrix:
-        distro: ["ubuntu2004", "debian10"]
+        include:
+          - distro: ubuntu-20.04
+            test_type: unit
+            ansible_version: '>=2.9, <2.10'
+            jinja2_version: '<3.1'
+            python_version: '3.8'
+            experimental: false
+          - distro: ubuntu-20.04
+            test_type: unit
+            ansible_version: '>=2.10, <2.11'
+            jinja2_version: '<3.1'
+            python_version: '3.8'
+            experimental: false
+          - distro: ubuntu-20.04
+            test_type: unit
+            python_version: '3.8'
+            jinja2_version: '<3.1'
+            experimental: true
+          - distro: ubuntu-22.04
+            test_type: unit
+            python_version: '3.10'
+            experimental: true
 
     steps:
-      - uses: "actions/checkout@v2"
-
-      - name: "Download test script"
-        run: |
-          wget -O tests/test.sh https://gist.githubusercontent.com/nickjj/d12353b5b601e33cd62fda111359957a/raw
-          chmod +x tests/test.sh
-
-      - name: "Run test suite"
-        run: |
-          ./tests/test.sh
-        env:
+      - uses: Rheinwerk/molecule@v1
+        with:
           distro: ${{ matrix.distro }}
+          test_type: ${{ matrix.test_type }}
+          ansible_version: ${{ matrix.ansible_version }}
+          jinja2_version: ${{ matrix.jinja2_version }}
+          python_version: ${{ matrix.python_version }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-22.04
+    needs: molecule
+    # https://github.com/actions/runner/issues/491#issuecomment-850884422
+    if: |
+      always() &&
+      startsWith(github.event.ref, 'refs/tags/v') &&
+      (needs.molecule.result == 'success' || needs.molecule.result == 'skipped')
+    steps:
+      # Ansible ist bereits im Ubuntu Image enthalten, wir brauchen keine spezielle Version für den Galaxy Import: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      # AnsibleLint config wird anscheinend ignoriert: https://github.com/ansible/galaxy/issues/2868
+      - name: Trigger import of Role at Ansible Galaxy
+        run: |
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo $GITHUB_REPOSITORY | cut -d/ -f1) $(echo $GITHUB_REPOSITORY | cut -d/ -f2)

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,21 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces: {max-spaces-inside: 1, level: error}
+  brackets: {max-spaces-inside: 1, level: error}
+  colons: {max-spaces-after: -1, level: error}
+  commas: {max-spaces-after: -1, level: error}
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: {max: 3, level: error}
+  hyphens: {level: error}
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: {type: unix}
+  trailing-spaces: disable
+  truthy: disable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## What is ansible-docker? ![CI](https://github.com/nickjj/ansible-docker/workflows/CI/badge.svg?branch=master)
+Forked from: https://github.com/nickjj/ansible-docker
+
+## What is ansible-docker?
 
 It is an [Ansible](http://www.ansible.com/home) role to:
 
@@ -25,11 +27,6 @@ with it then check out
 - Ubuntu 22.04 LTS (Jammy Jellyfish)
 - Debian 10 (Buster)
 - Debian 11 (Bullseye)
-
----
-
-*You are viewing the master branch's documentation which might be ahead of the
-latest release. [Switch to the latest release](https://github.com/nickjj/ansible-docker/tree/v2.2.0).*
 
 ---
 
@@ -166,7 +163,7 @@ ansible all -m apt -a "name=docker-compose-plugin autoremove=true purge=true sta
 
 ### Installing Docker Compose v1
 
-Docker Compose v1 will get PIP installed inside of a Virtualenv. If you plan to
+Docker Compose v1 will get PIP installed inside of a Virtualenv, if `docker__pip_virtualenv` is true . If you plan to
 use Docker Compose v2 instead it will be very easy to skip installing v1
 although technically both can be installed together since v1 is accessed with
 `docker-compose` and v2 is accessed with `docker compose` (notice the lack of
@@ -212,11 +209,11 @@ it's worth knowing this up front. You can enable User Namespaces and any
 other options with the `docker__daemon_json` variable which is explained later.
 
 ```yml
+# Default: do not add any user to docker group
+docker__users: []
+
 # Try to use the sudo user by default, but fall back to root.
 docker__users: ["{{ ansible_env.SUDO_USER | d('root') }}"]
-
-# For example, if the user you want to set is different than the sudo user.
-docker__users: ["admin"]
 ```
 
 ### Configuring Docker registry logins
@@ -272,8 +269,7 @@ docker__daemon_json: ""
 ### Configure the Docker daemon options (flags)
 
 Flags that are set when starting the Docker daemon cannot be changed in the
-`daemon.json` file. By default Docker sets `-H unix://` which means that option
-cannot be changed with the json options.
+`daemon.json` file.
 
 Add or change the starting Docker daemon flags by supplying them exactly how
 they would appear on the command line.
@@ -286,8 +282,6 @@ they would appear on the command line.
 docker__daemon_flags:
   - "-H unix://"
 ```
-
-*If you don't supply some type of `-H` flag here, Docker will fail to start.*
 
 ### Configuring the Docker daemon environment variables
 
@@ -316,8 +310,7 @@ docker__systemd_override: ""
 
 ### Configuring Docker related cron jobs
 
-By default this will safely clean up disk space used by Docker every Sunday at
-midnight.
+If `docker__cron_jobs_enable` is set to true, a cronjob will safely clean up disk space used by Docker every Sunday at midnight.
 
 ```yml
 # `a` removes unused images (useful in production).
@@ -386,10 +379,11 @@ docker__apt_repository: >
 #### Configuring Virtualenv
 
 Rather than pollute your server's version of Python, all PIP packages are
-installed into a Virtualenv of your choosing.
+installed into a Virtualenv of your choosing, if `docker__pip_virtualenv` is set to true.
 
 ```yml
-docker__pip_virtualenv: "/usr/local/lib/docker/virtualenv"
+docker__pip_virtualenv: true
+docker__pip_virtualenv_path: "/usr/local/lib/docker/virtualenv"
 ```
 
 #### Installing PIP and its dependencies
@@ -416,7 +410,7 @@ docker__default_pip_packages:
   - name: "docker-compose"
     version: "{{ docker__compose_version }}"
     path: "/usr/local/bin/docker-compose"
-    src: "{{ docker__pip_virtualenv + '/bin/docker-compose' }}"
+    src: "{{ docker__pip_virtualenv_path + '/bin/docker-compose' }}"
     state: "{{ docker__pip_docker_compose_state }}"
 
 # Add your own PIP packages with the same properties as above.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ docker__state: "present"
 docker__compose_version: ""
 docker__compose_v2_version: ""
 
-docker__users: ["{{ ansible_env.SUDO_USER | d('root') }}"]
+docker__users: []
 
 docker__login_become_user: "{{ docker__users | first | d('root') }}"
 
@@ -22,13 +22,13 @@ docker__default_daemon_json: |
 
 docker__daemon_json: ""
 
-docker__daemon_flags:
-  - "-H unix://"
+docker__daemon_flags: []
 
 docker__daemon_environment: []
 
 docker__systemd_override: ""
 
+docker__cron_jobs_enable: false
 docker__cron_jobs_prune_flags: "af"
 docker__cron_jobs_prune_schedule: ["0", "0", "*", "*", "0"]
 docker__cron_jobs:
@@ -57,7 +57,7 @@ docker__apt_key_url: "https://download.docker.com/linux/{{ ansible_distribution 
 docker__apt_repository: >
   deb [arch={{ docker__architecture_map[ansible_architecture] }}]
   https://download.docker.com/linux/{{ ansible_distribution | lower }}
-  {{ ansible_distribution_release }} {{ docker__channel | join (' ') }}
+  {{ ansible_distribution_release }} {{ docker__channel | join(' ') }}
 
 docker__pip_dependencies:
   - "gcc"
@@ -66,7 +66,8 @@ docker__pip_dependencies:
   - "python3-pip"
   - "virtualenv"
 
-docker__pip_virtualenv: "/usr/local/lib/docker/virtualenv"
+docker__pip_virtualenv: false
+docker__pip_virtualenv_path: "/usr/local/lib/docker/virtualenv"
 
 docker__default_pip_packages:
   - name: "docker"
@@ -74,7 +75,7 @@ docker__default_pip_packages:
   - name: "docker-compose"
     version: "{{ docker__compose_version }}"
     path: "/usr/local/bin/docker-compose"
-    src: "{{ docker__pip_virtualenv + '/bin/docker-compose' }}"
+    src: "{{ docker__pip_virtualenv_path + '/bin/docker-compose' }}"
     state: "{{ docker__pip_docker_compose_state }}"
 docker__pip_packages: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,11 @@
 ---
-
 galaxy_info:
-  role_name: "docker"
-  author: "Nick Janetakis"
+  author: Michael Schmitz
+  role_name: docker
+  namespace: rheinwerk
   description: "Install and configure Docker / Docker Compose."
   license: "MIT"
-  min_ansible_version: "2.10.0"
+  min_ansible_version: 2.9.0
 
   platforms:
     - name: "Ubuntu"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 
 - name: Disable pinned Docker version
-  ansible.builtin.file:
+  file:
     dest: "/etc/apt/preferences.d/docker.pref"
     state: "absent"
   when: not docker__version | d()
 
 - name: Disable pinned Docker Compose v2 version
-  ansible.builtin.file:
+  file:
     dest: "/etc/apt/preferences.d/docker-compose-plugin.pref"
     state: "absent"
   when: not docker__compose_v2_version | d()
 
 - name: Enable pinned Docker version
-  ansible.builtin.template:
+  template:
     src: "etc/apt/preferences.d/docker.pref.j2"
     dest: "/etc/apt/preferences.d/docker.pref"
     owner: "root"
@@ -22,7 +22,7 @@
   when: docker__version | d()
 
 - name: Enable pinned Docker Compose v2 version
-  ansible.builtin.template:
+  template:
     src: "etc/apt/preferences.d/docker-compose-plugin.pref.j2"
     dest: "/etc/apt/preferences.d/docker-compose-plugin.pref"
     owner: "root"
@@ -33,21 +33,22 @@
 - name: Install Docker's dependencies
   retries: 20
   delay: 15
-  ansible.builtin.apt:
+  apt:
     name: "{{ docker__package_dependencies + docker__pip_dependencies }}"
+    update_cache: true
 
 - name: Add Docker's public GPG key to the APT keyring
-  ansible.builtin.apt_key:
+  apt_key:
     id: "{{ docker__apt_key_id }}"
     url: "{{ docker__apt_key_url }}"
 
 - name: Configure Docker's upstream APT repository
-  ansible.builtin.apt_repository:
+  apt_repository:
     repo: "{{ docker__apt_repository }}"
     update_cache: true
 
 - name: Create Docker configuration directories
-  ansible.builtin.file:
+  file:
     path: "{{ item }}"
     state: "directory"
     owner: "root"
@@ -58,7 +59,7 @@
     - "/etc/systemd/system/docker.service.d"
 
 - name: Configure Docker daemon options (json)
-  ansible.builtin.template:
+  template:
     src: "etc/docker/daemon.json.j2"
     dest: "/etc/docker/daemon.json"
     owner: "root"
@@ -66,53 +67,66 @@
     mode: "0644"
   notify: ["Restart Docker"]
 
-- name: Install Docker and Docker Compose v2
+- name: Install Docker and Docker Compose v2 # noqa args[module]
   retries: 20
   delay: 15
-  ansible.builtin.apt:
+  apt:
     name:
       - "docker-{{ docker__edition }}"
       - "docker-compose-plugin"
     state: "{{ docker__state }}"
 
-- name: Install Python packages
-  ansible.builtin.pip:
+- name: Virtualenv block
+  when: docker__pip_virtualenv
+  block:
+    - name: Install Python packages # noqa args[module]
+      pip:
+        name: >
+          {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
+        virtualenv: "{{ docker__pip_virtualenv_path }}"
+        virtualenv_python: "python3"
+        state: "{{ item.state | d('present') }}"
+      loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
+      when: item.name | d()
+
+    - name: Create python3-docker proxy script to access the Virtualenv's interpreter
+      template:
+        src: "usr/local/bin/python3-docker.j2"
+        dest: "/usr/local/bin/python3-docker"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
+    - name: Symlink selected Python package binaries to /usr/local/bin
+      file:
+        path: "{{ item.path }}"
+        src: "{{ item.src }}"
+        force: true
+        state: "link"
+      loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
+      when:
+        - item.state | d("present") != "absent"
+        - item.path | d() and item.src | d()
+
+- name: Install Python packages # noqa args[module]
+  pip:
     name: >
       {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
-    virtualenv: "{{ docker__pip_virtualenv }}"
-    virtualenv_python: "python3"
     state: "{{ item.state | d('present') }}"
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
-  when: item.name | d()
-
-- name: Create python3-docker proxy script to access the Virtualenv's interpreter
-  ansible.builtin.template:
-    src: "usr/local/bin/python3-docker.j2"
-    dest: "/usr/local/bin/python3-docker"
-    owner: "root"
-    group: "root"
-    mode: "0755"
-
-- name: Symlink selected Python package binaries to /usr/local/bin
-  ansible.builtin.file:
-    path: "{{ item.path }}"
-    src: "{{ item.src }}"
-    force: true
-    state: "link"
-  loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
   when:
-    - item.state | d("present") != "absent"
-    - item.path | d() and item.src | d()
+    - not docker__pip_virtualenv
+    - item.name | d()
 
 - name: Add user(s) to "docker" group
-  ansible.builtin.user:
+  user:
     name: "{{ item }}"
     groups: "docker"
     append: true
   loop: "{{ docker__users }}"
 
 - name: Configure Docker daemon options (flags)
-  ansible.builtin.template:
+  template:
     src: "etc/systemd/system/docker.service.d/options.conf.j2"
     dest: "/etc/systemd/system/docker.service.d/options.conf"
     owner: "root"
@@ -121,7 +135,7 @@
   notify: ["Reload systemd daemon", "Restart Docker"]
 
 - name: Configure Docker daemon environment variables
-  ansible.builtin.template:
+  template:
     src: "etc/systemd/system/docker.service.d/environment.conf.j2"
     dest: "/etc/systemd/system/docker.service.d/environment.conf"
     owner: "root"
@@ -130,7 +144,7 @@
   notify: ["Reload systemd daemon", "Restart Docker"]
 
 - name: Configure custom systemd unit file override
-  ansible.builtin.template:
+  template:
     src: "etc/systemd/system/docker.service.d/custom.conf.j2"
     dest: "/etc/systemd/system/docker.service.d/custom.conf"
     owner: "root"
@@ -139,12 +153,12 @@
   notify: ["Reload systemd daemon", "Restart Docker"]
 
 - name: Restart Docker now to make sure `docker login` works
-  ansible.builtin.meta: "flush_handlers"
+  meta: "flush_handlers"
 
 # It's safe to ignore no-log-password because we're removing the password from
 # the output with the loop_control property.
 - name: Manage Docker registry login credentials
-  ansible.builtin.docker_login:  # noqa no-log-password
+  docker_login:  # noqa no-log-password
     registry_url: "{{ item.registry_url | d(omit) }}"
     username: "{{ item.username }}"
     password: "{{ item.password }}"
@@ -162,16 +176,17 @@
     ansible_python_interpreter: "{{ '/usr/bin/env python3-docker' }}"
 
 - name: Remove Docker related cron jobs
-  ansible.builtin.file:
+  file:
     path: "/etc/cron.d/{{ item.cron_file }}"
     state: "absent"
   loop: "{{ docker__cron_jobs }}"
   when:
+    - not docker__cron_jobs_enable
     - item.state | d("present") == "absent"
     - item.cron_file | d()
 
 - name: Create Docker related cron jobs
-  ansible.builtin.cron:
+  cron:
     name: "{{ item.name }}"
     job: "{{ item.job }}"
     minute: "{{ item.schedule[0] }}"
@@ -183,6 +198,7 @@
     user: "{{ item.user | d('root') }}"
   loop: "{{ docker__cron_jobs }}"
   when:
+    - docker__cron_jobs_enable
     - item.state | d("present") != "absent"
     - item.name | d() and item.job | d()
     - item.schedule | d() and item.cron_file | d()


### PR DESCRIPTION
- Alte Rolle https://github.com/Rheinwerk/docker.ubuntu wird aufgegeben, diese mischte zu viele Inhalte aus verschiedenen Bereichen ( Kernel + Module, PIP Basics etc.) und war mehr auf alte Ubuntu Versionen ausgerichtet
- Geforkte Rolle wurde an Bedürfnisse angepasst und verhält sich mit den übergebenen Packerwerten wie die alte in Bezug auf Daemon Konfigationen, User und Versionen:
- Abweichungen zu Upstream:
  - Virtualenv ist optional
  - Docker Daemon Flags sind nicht gesetzt
  - Docker Cronjobs sind deaktviert
  - Tasks für 2.9 backported
  - Füge keinen User zur Dockergruppe hinzu