### PR TITLE
[#183179892] Ansible: Setze `PIP_ROOT_USER_ACTION` Variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,6 +118,8 @@
       {{ item.name }}{% if item.version | d() %}=={{ item.version }}{% endif %}
     state: "{{ item.state | d('present') }}"
   loop: "{{ docker__default_pip_packages + docker__pip_packages }}"
+  environment:
+    PIP_ROOT_USER_ACTION: ignore
   when:
     - not docker__pip_virtualenv
     - item.name | d()


### PR DESCRIPTION
Pip warnt nun, falls der Root User außerhalb von Virtualenv verwendet wird
- https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-root-user-action
- Wurde durch https://github.com/pypa/pip/issues/6409 verursacht
- Mit https://github.com/pypa/pip/issues/10556 wurde die Option zum ignorieren hinzugefügt